### PR TITLE
fix: umi-plugin-stillness给每个路由加上type,用于外部控制缓存状态

### DIFF
--- a/examples/umi/package.json
+++ b/examples/umi/package.json
@@ -27,9 +27,9 @@
     "react": "17.x",
     "react-dom": "17.x",
     "react-router-dom": "5.2.0",
-    "react-stillness-component": "0.6.1",
+    "react-stillness-component": "0.6.3",
     "umi": "^3.5.26",
-    "umi-plugin-stillness": "0.1.1"
+    "umi-plugin-stillness": "0.1.3"
   },
   "devDependencies": {
     "@types/react": "^17.0.0",

--- a/examples/umi/src/components/Count/index.tsx
+++ b/examples/umi/src/components/Count/index.tsx
@@ -1,22 +1,23 @@
 import React, { useState } from 'react';
-import { useStillness, useStillnessManager } from 'react-stillness-component';
+import { useStillness, useStillnessManager } from 'umi';
 
 export default function Count() {
   const [count, setCount] = useState(0);
-  const stillnessManager  = useStillnessManager();
+  const stillnessManager = useStillnessManager();
   const collected = useStillness({
     mounted: (contract) => {
-      return "mounted";
+      console.log('被隐藏');
+      return 'mounted';
     },
     unmounted: (contract) => {
-      return "unmounted";
+      return 'unmounted';
     },
     collect: (contract) => {
       return {
         isStillness: contract.isStillness(),
-        stillnessId: contract.getStillnessId()
+        stillnessId: contract.getStillnessId(),
       };
-    }
+    },
   });
 
   return (

--- a/examples/umi/src/pages/home.tsx
+++ b/examples/umi/src/pages/home.tsx
@@ -1,13 +1,22 @@
-import React from "react";
-import { Link } from 'umi';
+import React from 'react';
+import { Link, useStillnessManager } from 'umi';
 
-function Home(props:any) {
+function Home(props: any) {
+  const manager = useStillnessManager();
+
   return (
     <div>
       <h2>Home</h2>
       {/* <Link to="/home">Go to home page</Link>
       <Link to="/list">Go to list page</Link>
       <Link to="/about">Go to about page</Link> */}
+      <button
+        onClick={() => {
+          manager.getActions().triggerUnset({ type: '/home' });
+        }}
+      >
+        清除home child data
+      </button>
       <hr />
       {props.children}
     </div>

--- a/packages/react-stillness/src/core/classes/StillnessMonitorImpl.ts
+++ b/packages/react-stillness/src/core/classes/StillnessMonitorImpl.ts
@@ -40,7 +40,10 @@ export class StillnessMonitorImpl implements StillnessMonitor {
   ): Unsubscribe {
     const { parentId } = params;
     invariant(typeof listener === 'function', 'listener must be a function.');
-    invariant(typeof parentId === 'string', 'parentId is required');
+    invariant(
+      typeof parentId === 'string',
+      'parentId is required,Expected need Offscreen component'
+    );
 
     let prevOperation = this.store.getState().operation;
     const handleChange = () => {

--- a/packages/umi-plugin-stillness/src/assets/exports.tpl
+++ b/packages/umi-plugin-stillness/src/assets/exports.tpl
@@ -1,2 +1,8 @@
-export * from 'react-stillness-component';
+export {
+  useStillness,
+  useStillnessManager,
+  Offscreen,
+  connectStillness,
+  StillnessProvider,
+} from 'react-stillness-component';
 export { IRoute as StillnessIRoute } from "umi-renderer-stillness";

--- a/packages/umi-plugin-stillness/src/index.ts
+++ b/packages/umi-plugin-stillness/src/index.ts
@@ -23,6 +23,7 @@ export default (api: IApi) => {
         join(__dirname, 'assets/exports.tpl'),
         'utf-8'
       );
+
       api.writeTmpFile({
         path: 'plugin-stillness/exports.ts',
         content: exportsTpl,

--- a/packages/umi-renderer-stillness/src/renderClient/renderClient.tsx
+++ b/packages/umi-renderer-stillness/src/renderClient/renderClient.tsx
@@ -70,9 +70,9 @@ function RouterComponent(props: IRouterComponentProps) {
   }, [history]);
 
   return (
-    <Router history={history}>
-      <StillnessProvider>{renderRoutes(renderRoutesProps)}</StillnessProvider>
-    </Router>
+    <StillnessProvider>
+      <Router history={history}>{renderRoutes(renderRoutesProps)}</Router>
+    </StillnessProvider>
   );
 }
 

--- a/packages/umi-renderer-stillness/src/renderRoutes/StillnessSwitch.tsx
+++ b/packages/umi-renderer-stillness/src/renderRoutes/StillnessSwitch.tsx
@@ -34,7 +34,7 @@ export default function Switch(props: any) {
 
               if (child.props.stillness) {
                 return (
-                  <Offscreen visible={childMatch !== null}>
+                  <Offscreen type={path} visible={childMatch !== null}>
                     {cloneElement(element, {
                       location,
                       computedMatch: childMatch,

--- a/yarn.lock
+++ b/yarn.lock
@@ -14523,6 +14523,16 @@ react-stillness-component@0.6.0:
     invariant "^2.2.4"
     redux "^4.1.2"
 
+react-stillness-component@0.6.1:
+  version "0.6.1"
+  resolved "https://registry.npmjs.org/react-stillness-component/-/react-stillness-component-0.6.1.tgz#bdd7a473e530be20900688b91989085e2c905c9e"
+  integrity sha512-BG9+mmXvO/VVw69Jo+qseHT8fibq20PWjzTvwbK3OtmNNZMb1iwOYX4+ag+VXaEVYL2RLapXs6DcumdgwpmCMg==
+  dependencies:
+    fast-deep-equal "^3.1.3"
+    hoist-non-react-statics "^3.3.2"
+    invariant "^2.2.4"
+    redux "^4.1.2"
+
 react-tween-state@^0.1.5:
   version "0.1.5"
   resolved "https://registry.npmjs.org/react-tween-state/-/react-tween-state-0.1.5.tgz#e98b066551efb93cb92dd1be14995c2e3deae339"


### PR DESCRIPTION
affects: react-stillness-component, umi-plugin-stillness, umi-renderer-stillness